### PR TITLE
Feat/#48 feat 다트 인터랙션 진입 시 게임 방법 설명 구현

### DIFF
--- a/Shoong/Shoong.xcodeproj/project.pbxproj
+++ b/Shoong/Shoong.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		034D28032A795B74001D3561 /* HowToPlay.swift in Sources */ = {isa = PBXBuildFile; fileRef = 034D28022A795B74001D3561 /* HowToPlay.swift */; };
 		035FABB32A783EF3009D1FED /* SF-Pro.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 1AF161A42A739F5600923F2F /* SF-Pro.ttf */; };
 		035FABB52A783FD9009D1FED /* GuageBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 035FABB42A783FD9009D1FED /* GuageBar.swift */; };
 		035FABB72A783FF4009D1FED /* ThrownCount.swift in Sources */ = {isa = PBXBuildFile; fileRef = 035FABB62A783FF4009D1FED /* ThrownCount.swift */; };
@@ -59,6 +60,7 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		034D28022A795B74001D3561 /* HowToPlay.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HowToPlay.swift; sourceTree = "<group>"; };
 		035FABB42A783FD9009D1FED /* GuageBar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GuageBar.swift; sourceTree = "<group>"; };
 		035FABB62A783FF4009D1FED /* ThrownCount.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThrownCount.swift; sourceTree = "<group>"; };
 		035FABB82A78401C009D1FED /* SpriteKitContainer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpriteKitContainer.swift; sourceTree = "<group>"; };
@@ -286,6 +288,7 @@
 				035FABB62A783FF4009D1FED /* ThrownCount.swift */,
 				035FABB82A78401C009D1FED /* SpriteKitContainer.swift */,
 				035FABC02A784AB2009D1FED /* HapticManager.swift */,
+				034D28022A795B74001D3561 /* HowToPlay.swift */,
 			);
 			path = Dart;
 			sourceTree = "<group>";
@@ -452,6 +455,7 @@
 				1A5DC90B2A7795A400E7906E /* BowlingGameScene.swift in Sources */,
 				1AF161BB2A73A85300923F2F /* TemplateCrumpleScriptView.swift in Sources */,
 				035FABB92A78401C009D1FED /* SpriteKitContainer.swift in Sources */,
+				034D28032A795B74001D3561 /* HowToPlay.swift in Sources */,
 				ACB061412A723C1E00D31CCF /* SlingShotGameScene.swift in Sources */,
 				1AF161A72A73A16B00923F2F /* InteractionCardView.swift in Sources */,
 				1AF161B82A73A67E00923F2F /* TextEditorView.swift in Sources */,

--- a/Shoong/Shoong/Interaction/Dart/DartView.swift
+++ b/Shoong/Shoong/Interaction/Dart/DartView.swift
@@ -8,6 +8,8 @@
 import SwiftUI
 
 struct DartView: View {
+    @State private var isMessagePresented = true
+
     var body: some View {
         ZStack(alignment: .bottom) {
             SpriteKitContainer(scene: DartScene())
@@ -21,6 +23,9 @@ struct DartView: View {
                 .padding(.leading, 19)
                 .padding(.trailing, 16)
                 .padding(.bottom, 24)
+            }
+            if isMessagePresented {
+                HowToPlay(playImageName: "dartHowToPlay", isMessagePresented: $isMessagePresented)
             }
         }
     }

--- a/Shoong/Shoong/Interaction/Dart/HowToPlay.swift
+++ b/Shoong/Shoong/Interaction/Dart/HowToPlay.swift
@@ -1,0 +1,34 @@
+//
+//  HowToPlay.swift
+//  Shoong
+//
+//  Created by 금가경 on 2023/08/02.
+//
+
+import SwiftUI
+
+struct HowToPlay: View {
+    let playImageName : String
+    @Binding var isMessagePresented : Bool
+    
+    var body: some View {
+        ZStack {
+            Rectangle()
+                .ignoresSafeArea()
+                .opacity(0.5)
+            VStack(spacing: 18) {
+                Image(playImageName)
+                Button(action: {
+                    isMessagePresented = false
+                }, label: {
+                    Image("xmark")})
+            }
+        }
+    }
+}
+
+struct HowToPlay_Previews: PreviewProvider {
+    static var previews: some View {
+        HowToPlay(playImageName: "dartHowToPlay", isMessagePresented: .constant(true))
+    }
+}


### PR DESCRIPTION
## 개요 및 관련 이슈
<!-- PR이 열린 이유와 작업 내용 -->
<!-- - 메인 홈 뷰의 UI를 전체 구현했습니다.(예시) -->
#48 
다트 인터랙션 진입 시 게임 방법을 설명하는 것을 구현했습니다. 

## 작업 사항
<!-- - 관리자용 대시보드 구현(예시) -->
<!-- - 관리자용 권한 수정 버튼 추가(예시) -->
- 버튼 컴포넌트 만들기
- 다트 진입 시 게임 방법 설명
## 주요 로직(Optional)
```diff
- print("변경 전")
+ print("변경 후")
```
