### PR TITLE
[Feat] 날린 횟수 증가시켜서 뷰에 보여주기

### DIFF
--- a/Shoong/Shoong/Interaction/Dart/DartScene.swift
+++ b/Shoong/Shoong/Interaction/Dart/DartScene.swift
@@ -12,7 +12,8 @@ import SpriteKit
 import SwiftUI
 
 // SKPhysicsContactDelegate : 충돌 감지에 필요한 프로토콜
-final class DartScene: SKScene, SKPhysicsContactDelegate {
+final class DartScene: SKScene, SKPhysicsContactDelegate, ObservableObject {
+    @Published var throwingCount : Int = 0
     
     // 화면 관련 변수
     let screenWidth = UIScreen.main.bounds.width
@@ -165,6 +166,7 @@ final class DartScene: SKScene, SKPhysicsContactDelegate {
             darts.last?.physicsBody?.isDynamic = false
             playSound()
             hapticManager?.playHaptic()
+            throwingCount += 1
         }
         
         // 충돌 시 새 다트 생성
@@ -181,6 +183,7 @@ final class DartScene: SKScene, SKPhysicsContactDelegate {
         // 다트가 화면 밖으로 나갔을 때
         if collideBody.categoryBitMask == PhysicsCategory.border {
             print("border!")
+            throwingCount += 1
             darts.popLast()?.removeFromParent()
         }
     }

--- a/Shoong/Shoong/Interaction/Dart/DartView.swift
+++ b/Shoong/Shoong/Interaction/Dart/DartView.swift
@@ -6,17 +6,19 @@
 //
 
 import SwiftUI
+import SpriteKit
 
 struct DartView: View {
     @State private var isMessagePresented = true
-
+    @StateObject private var dartScene = DartScene()
+    
     var body: some View {
         ZStack(alignment: .bottom) {
-            SpriteKitContainer(scene: DartScene())
+            SpriteKitContainer(scene: dartScene)
                 .ignoresSafeArea()
             ZStack{
                 HStack(alignment: .bottom) {
-                    ThrownCount()
+                    ThrownCount(count: dartScene.throwingCount)
                     Spacer()
                     GuageBar()
                 }

--- a/Shoong/Shoong/Interaction/Dart/ThrownCount.swift
+++ b/Shoong/Shoong/Interaction/Dart/ThrownCount.swift
@@ -8,6 +8,8 @@
 import SwiftUI
 
 struct ThrownCount: View {
+    let count: Int
+    
     var body: some View {
         ZStack {
             RoundedRectangle(cornerRadius: 5)
@@ -16,7 +18,7 @@ struct ThrownCount: View {
             VStack {
                 Text("날린 사직서 갯수")
                     .font(.custom("SFPro-Regular", size: 11))
-                Text("0")
+                Text("\(count)")
                     .font(.custom("SFPro-Semibold", size: 15))
             }
         }
@@ -25,6 +27,6 @@ struct ThrownCount: View {
 
 struct ThrownCount_Previews: PreviewProvider {
     static var previews: some View {
-        ThrownCount()
+        ThrownCount(count: 3)
     }
 }


### PR DESCRIPTION
## 개요 및 관련 이슈
<!-- PR이 열린 이유와 작업 내용 -->
<!-- - 메인 홈 뷰의 UI를 전체 구현했습니다.(예시) -->
날린 횟수를 증가시켜서 뷰에 보여줍니다. 

## 작업 사항
<!-- - 관리자용 대시보드 구현(예시) -->
<!-- - 관리자용 권한 수정 버튼 추가(예시) -->
- 날린 횟수 증가시켜서 뷰에 보여주기

## 주요 로직(Optional)
```diff
- print("변경 전")
+ print("변경 후")
```
