### PR TITLE
[Feat] CoreData구축

### DIFF
--- a/Shoong/Shoong.xcodeproj/project.pbxproj
+++ b/Shoong/Shoong.xcodeproj/project.pbxproj
@@ -40,6 +40,9 @@
 		1AF161BF2A73A86E00923F2F /* TemplateCrumpleView2.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1AF161BE2A73A86E00923F2F /* TemplateCrumpleView2.swift */; };
 		1AF161C12A73A87500923F2F /* TemplateCrumpleView3.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1AF161C02A73A87500923F2F /* TemplateCrumpleView3.swift */; };
 		1AF161C32A73A88200923F2F /* TemplateCrumpleView4.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1AF161C22A73A88200923F2F /* TemplateCrumpleView4.swift */; };
+		AC5D9EBA2A7A7B2700F3B519 /* PairSet.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC5D9EB92A7A7B2700F3B519 /* PairSet.swift */; };
+		AC5D9EBC2A7A7B4000F3B519 /* CoreDataViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC5D9EBB2A7A7B4000F3B519 /* CoreDataViewModel.swift */; };
+		AC5D9EBF2A7A7B5C00F3B519 /* CoreDataContainer.xcdatamodeld in Sources */ = {isa = PBXBuildFile; fileRef = AC5D9EBD2A7A7B5C00F3B519 /* CoreDataContainer.xcdatamodeld */; };
 		ACB0611C2A72386300D31CCF /* ShoongApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = ACB0611B2A72386300D31CCF /* ShoongApp.swift */; };
 		ACB0611E2A72386300D31CCF /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = ACB0611D2A72386300D31CCF /* ContentView.swift */; };
 		ACB061202A72386400D31CCF /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = ACB0611F2A72386400D31CCF /* Assets.xcassets */; };
@@ -94,6 +97,9 @@
 		1AF161BE2A73A86E00923F2F /* TemplateCrumpleView2.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TemplateCrumpleView2.swift; sourceTree = "<group>"; };
 		1AF161C02A73A87500923F2F /* TemplateCrumpleView3.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TemplateCrumpleView3.swift; sourceTree = "<group>"; };
 		1AF161C22A73A88200923F2F /* TemplateCrumpleView4.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TemplateCrumpleView4.swift; sourceTree = "<group>"; };
+		AC5D9EB92A7A7B2700F3B519 /* PairSet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PairSet.swift; sourceTree = "<group>"; };
+		AC5D9EBB2A7A7B4000F3B519 /* CoreDataViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoreDataViewModel.swift; sourceTree = "<group>"; };
+		AC5D9EBE2A7A7B5C00F3B519 /* CoreDataContainer.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = CoreDataContainer.xcdatamodel; sourceTree = "<group>"; };
 		ACB061182A72386300D31CCF /* Shoong.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Shoong.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		ACB0611B2A72386300D31CCF /* ShoongApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShoongApp.swift; sourceTree = "<group>"; };
 		ACB0611D2A72386300D31CCF /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
@@ -192,6 +198,32 @@
 			path = TemplateCrumpleView;
 			sourceTree = "<group>";
 		};
+		AC5D9EB52A7A7AE400F3B519 /* CoreData */ = {
+			isa = PBXGroup;
+			children = (
+				AC5D9EB72A7A7AFB00F3B519 /* CoreDataModel */,
+				AC5D9EB62A7A7AF000F3B519 /* CoreDataViewModel */,
+			);
+			path = CoreData;
+			sourceTree = "<group>";
+		};
+		AC5D9EB62A7A7AF000F3B519 /* CoreDataViewModel */ = {
+			isa = PBXGroup;
+			children = (
+				AC5D9EBB2A7A7B4000F3B519 /* CoreDataViewModel.swift */,
+				AC5D9EBD2A7A7B5C00F3B519 /* CoreDataContainer.xcdatamodeld */,
+			);
+			path = CoreDataViewModel;
+			sourceTree = "<group>";
+		};
+		AC5D9EB72A7A7AFB00F3B519 /* CoreDataModel */ = {
+			isa = PBXGroup;
+			children = (
+				AC5D9EB92A7A7B2700F3B519 /* PairSet.swift */,
+			);
+			path = CoreDataModel;
+			sourceTree = "<group>";
+		};
 		ACB0610F2A72386300D31CCF = {
 			isa = PBXGroup;
 			children = (
@@ -211,6 +243,7 @@
 		ACB0611A2A72386300D31CCF /* Shoong */ = {
 			isa = PBXGroup;
 			children = (
+				AC5D9EB52A7A7AE400F3B519 /* CoreData */,
 				1AF161AD2A73A26B00923F2F /* Info.plist */,
 				ACB061352A7238E300D31CCF /* Extension+Modifier */,
 				ACB0612C2A72389100D31CCF /* Interaction */,
@@ -443,6 +476,7 @@
 				1AF161BD2A73A86700923F2F /* TemplateCrumpleView1.swift in Sources */,
 				035FABB52A783FD9009D1FED /* GuageBar.swift in Sources */,
 				1AF161AA2A73A17D00923F2F /* InteractionSelectView.swift in Sources */,
+				AC5D9EBC2A7A7B4000F3B519 /* CoreDataViewModel.swift in Sources */,
 				035FABB72A783FF4009D1FED /* ThrownCount.swift in Sources */,
 				1AF161B62A73A64F00923F2F /* TextDragGestureView.swift in Sources */,
 				ACB061432A723C2A00D31CCF /* BowlingView.swift in Sources */,
@@ -453,6 +487,7 @@
 				ACB061392A723B5100D31CCF /* TextBoxModel.swift in Sources */,
 				035FABBD2A784595009D1FED /* PhysicsCategory.swift in Sources */,
 				1AF161B02A73A5B200923F2F /* SelectedTemplateView.swift in Sources */,
+				AC5D9EBF2A7A7B5C00F3B519 /* CoreDataContainer.xcdatamodeld in Sources */,
 				1A5DC90B2A7795A400E7906E /* BowlingGameScene.swift in Sources */,
 				035FABB92A78401C009D1FED /* SpriteKitContainer.swift in Sources */,
 				034D28032A795B74001D3561 /* HowToPlay.swift in Sources */,
@@ -462,6 +497,7 @@
 				1AF161C32A73A88200923F2F /* TemplateCrumpleView4.swift in Sources */,
 				ACB061472A723C4300D31CCF /* DirTestView4.swift in Sources */,
 				ACB0611E2A72386300D31CCF /* ContentView.swift in Sources */,
+				AC5D9EBA2A7A7B2700F3B519 /* PairSet.swift in Sources */,
 				ACB061452A723C3500D31CCF /* BasicView.swift in Sources */,
 				ACB061372A72392200D31CCF /* MainView.swift in Sources */,
 				035FABBB2A78405D009D1FED /* DartScene.swift in Sources */,
@@ -671,6 +707,19 @@
 			defaultConfigurationName = Release;
 		};
 /* End XCConfigurationList section */
+
+/* Begin XCVersionGroup section */
+		AC5D9EBD2A7A7B5C00F3B519 /* CoreDataContainer.xcdatamodeld */ = {
+			isa = XCVersionGroup;
+			children = (
+				AC5D9EBE2A7A7B5C00F3B519 /* CoreDataContainer.xcdatamodel */,
+			);
+			currentVersion = AC5D9EBE2A7A7B5C00F3B519 /* CoreDataContainer.xcdatamodel */;
+			path = CoreDataContainer.xcdatamodeld;
+			sourceTree = "<group>";
+			versionGroupType = wrapper.xcdatamodel;
+		};
+/* End XCVersionGroup section */
 	};
 	rootObject = ACB061102A72386300D31CCF /* Project object */;
 }

--- a/Shoong/Shoong/CoreData/CoreDataModel/PairSet.swift
+++ b/Shoong/Shoong/CoreData/CoreDataModel/PairSet.swift
@@ -1,0 +1,16 @@
+//
+//  PairSet.swift
+//  Shoong
+//
+//  Created by Sup on 2023/08/02.
+//
+
+import SwiftUI
+
+// 보관함의 이미지 데이터 저장을 위한 model
+struct PairSet {
+    
+    var templateImageD: Data
+    var cardImageD: Data
+
+}

--- a/Shoong/Shoong/CoreData/CoreDataViewModel/CoreDataContainer.xcdatamodeld/CoreDataContainer.xcdatamodel/contents
+++ b/Shoong/Shoong/CoreData/CoreDataViewModel/CoreDataContainer.xcdatamodeld/CoreDataContainer.xcdatamodel/contents
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="21754" systemVersion="22F82" minimumToolsVersion="Automatic" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
+    <entity name="PairEntity" representedClassName="PairEntity" syncable="YES" codeGenerationType="class">
+        <attribute name="cardImageD" optional="YES" attributeType="Binary"/>
+        <attribute name="templateImageD" optional="YES" attributeType="Binary"/>
+    </entity>
+    <entity name="TemplatesEntity" representedClassName="TemplatesEntity" syncable="YES" codeGenerationType="class">
+        <attribute name="templateImageD" optional="YES" attributeType="Binary"/>
+    </entity>
+</model>

--- a/Shoong/Shoong/CoreData/CoreDataViewModel/CoreDataViewModel.swift
+++ b/Shoong/Shoong/CoreData/CoreDataViewModel/CoreDataViewModel.swift
@@ -1,0 +1,205 @@
+//
+//  CoreDataViewModel.swift
+//  Shoong
+//
+//  Created by Sup on 2023/08/02.
+//
+
+import SwiftUI
+import CoreData
+
+class CoreDataViewModel: ObservableObject {
+    
+    @State var numOne: Int = 0
+    @State var numTwo: Int = 0
+
+    
+    let container: NSPersistentContainer
+    
+    
+    @Published var templatesSavedEntities: [TemplatesEntity] = [] //최근을 위한 Template배열
+    @Published var pairsSavedEntities: [PairSet] = [] //보관함을 위한 PairSet([Template,Card]) 배열
+    
+    
+    
+    // container 초기화
+    init() {
+        container = NSPersistentContainer(name: "CoreDataContainer")
+        container.loadPersistentStores { (description, error) in
+            if let error = error {
+                print("Core Data loading erroe \(error)")
+            } else {
+                print("Successfully loaded Core Data ")
+            }
+        }
+        
+        // container 초기화할 때 각 Entity fetch해주기
+        fetchTemplates()
+        fetchPairs()
+        
+    }
+    
+    // ---------- Mark : 최근에 들어있는 Template에 대한 함수들 총4가지 [시작] ----------------
+    
+    // 1. Template에 대한 fetch
+    func fetchTemplates() {
+        
+        let request = NSFetchRequest<TemplatesEntity>(entityName: "TemplatesEntity")
+        
+        do {
+            // fetch성공시 templatesSavedEntities에 TemplatesEntity를 배열 형태로 담아주기
+            templatesSavedEntities = try container.viewContext.fetch(request)
+        } catch let error {
+            print("error fetching \(error)")
+        }
+        
+    }
+    
+    // 2. Temaplte 추가
+    @MainActor  //UI update은 main Thread에서 이루어져야해서 @MainActor사용
+    func addTemplate<V: View>(templateImageD: V, scale: CGFloat){
+        
+        // 저장된 tempalte 파일이 있으면서 && 저장된 tempalte이 5개 일때부터 추가될때마다 1개씩 삭제
+        if !templatesSavedEntities.isEmpty && (templatesSavedEntities.count > 4) {
+            deleteTemplate()
+        }
+        
+        // tempalte저장 entity가져오기
+        let newTemplate = TemplatesEntity(context: container.viewContext)
+        
+        // tempalteView 이미지 rendering
+        let renderingtemplateView = ImageRenderer(content: templateImageD)
+        
+        // 화질 문제로 무조건 rendering을 원하는 뷰에 @Environment(\.displayScale) var displayScale 를 넣어주고 displayscale을 addTemplate(scale:)로 넣어줘야 화질의 문제가 없음
+        renderingtemplateView.scale = scale
+        
+        //tempalteView를 Rendering한다음 UiImage로 변환
+        if let TemplateViewUimage = renderingtemplateView.uiImage {
+            // UiImage를 data로 변환해서 TemplatesEntity의 templateImageD에 담아주기
+            newTemplate.templateImageD = TemplateViewUimage.pngData()
+        }
+        // data저장
+        saveData()
+        
+        
+    }
+    
+    // 3. Temaplte 삭제
+    func deleteTemplate(){
+        
+        // template가 1개라도 있으면 templatesSavedEntities 배열에서 첫번째 삭제
+        if !templatesSavedEntities.isEmpty{
+            container.viewContext.delete(templatesSavedEntities.removeFirst())
+        }
+        // 변경내용 저장
+        saveData()
+    }
+    
+    // 4. Temaplte 저장
+    func saveData(){
+        
+        do {
+            try container.viewContext.save() // container saving
+            fetchTemplates() // save되면 Templates fetch시켜주기
+        } catch let error {
+            print("Error saving \(error)")
+        }
+        
+    }
+    // ---------- Mark : 최근에 들어있는 Template에 대한 함수들 [끝] ----------------
+    
+    // ---------- Mark : 보관함에 들어있는 Pair(Template,Card)에 대한 함수들 총 4가지 [시작] ----------------
+    
+    // 1. Pair(Template,Card)에 대한 fetch
+    func fetchPairs() {
+        
+        let request = NSFetchRequest<PairEntity>(entityName: "PairEntity")
+    
+        do {
+            // fetch 성공시 fetchedPairs에 Entity넣어주고
+            let fetchedPairs = try container.viewContext.fetch(request)
+            // PairEntity객체를 받아 PairSet으로 반환 [PairSet1, PairSet2 ...]
+            // ==>> [ [templateImageD, cardImageD], [templateImageD, cardImageD] ..] 형태로 반환
+            pairsSavedEntities = fetchedPairs.map { PairSet(templateImageD: $0.templateImageD!, cardImageD: $0.cardImageD!) }
+        } catch let error {
+            print("error fetching pairs \(error)")
+        }
+
+        
+    }
+    
+    // 2. Pair(Template,Card) 추가
+    @MainActor //UI update은 main Thread에서 이루어져야해서 @MainActor사용
+    func addPair<V1: View, V2: View>(templateView: V1, CardView: V2, scale: CGFloat) {
+        
+        // PairSet이 있으면서 && PairSet의 개수가 10개 초과면 삭제
+        if !pairsSavedEntities.isEmpty && (pairsSavedEntities.count > 9) {
+            deletePair()
+        }
+        
+        let newPair = PairEntity(context: container.viewContext)
+        
+        // 각 화면 rendering
+        let renderingTemplateView = ImageRenderer(content: templateView)
+        let renderingCardView = ImageRenderer(content: CardView)
+        
+        // 화질 문제로 무조건 rendering을 원하는 뷰에 @Environment(\.displayScale) var displayScale 를 넣어주고 displayscale을 addPair(scale:)로 넣어줘야 화질의 문제가 없음
+        renderingTemplateView.scale = scale
+        renderingCardView.scale = scale
+        
+        // renering한 화면 UiImage로 변환
+        if let templateViewUimage = renderingTemplateView.uiImage, let CardViewUimage = renderingCardView.uiImage  {
+            // UiImage들을 data로 변환하여 각 Attribute에 할당
+            newPair.templateImageD = templateViewUimage.pngData()
+            newPair.cardImageD = CardViewUimage.pngData()
+            
+        }
+        
+        // 변경내용 저장
+        savePairData()
+    }
+    
+    
+    
+
+    // 3. Pair(Template,Card) 삭제
+    func deletePair() {
+        
+        // pairSavedEntities 배열에 적어도 하나의 요소가 있는지 확인
+        if !pairsSavedEntities.isEmpty {
+            let request = NSFetchRequest<PairEntity>(entityName: "PairEntity")
+            
+            do {
+                let fetchedPairs = try container.viewContext.fetch(request)
+                
+                // Core Data에서 첫 번째 PairEntity 객체를 찾아 삭제
+                if let firstPair = fetchedPairs.first {
+                    container.viewContext.delete(firstPair)
+                    savePairData() // 변경 사항을 저장하고 pairSavedEntities 배열 업데이트
+                }
+            } catch let error {
+                print("error fetching pairs \(error)")
+            }
+        }
+        
+    }
+    
+    // 4. Pair(Template,Card)저장
+    func savePairData(){
+        
+        do {
+            try container.viewContext.save()
+            fetchPairs()
+        } catch let error {
+            print("Error saving \(error)")
+        }
+        
+    }
+    
+    // ---------- Mark : 보관함에 들어있는 Pair(Template,Card)에 대한 함수들 [끝] ----------------
+    
+    
+    
+    
+    
+}


### PR DESCRIPTION
## 개요 및 관련 이슈
- ImageRender는 WWDC22년 내용이라 아직 TextEidtor나 TextFiled가 Render안되는 문제가 있다.
   - 구글링해본 결과 현재(23.08.02)기준으로 Apple 자체의 버그인것으로 StackOverFlow의 답변자들도 추측하고 있다.
- 다행이 우리는 단순히 글자를 쓰는 방식이아니라 이 부분은 고려하지않고 진행함
<!-- PR이 열린 이유와 작업 내용 -->
<!-- - 메인 홈 뷰의 UI를 전체 구현했습니다.(예시) -->


## 작업 사항
- CoreData구축
<!-- - 관리자용 대시보드 구현(예시) -->
<!-- - 관리자용 권한 수정 버튼 추가(예시) -->

## 주요 로직(Optional)
```diff
- print("변경 전")
+ print("변경 후")
```
