### PR TITLE
[Design] 다트 레이아웃 조정

### DIFF
--- a/Shoong/Shoong/Interaction/Dart/DartScene.swift
+++ b/Shoong/Shoong/Interaction/Dart/DartScene.swift
@@ -121,9 +121,10 @@ final class DartScene: SKScene, SKPhysicsContactDelegate, ObservableObject {
     func createDart() {
         dart = SKSpriteNode(imageNamed: "jiggy_02")
         
+        dart.size = CGSize(width: 43.18, height: 56)
         dart.physicsBody?.affectedByGravity = false
-        dart.position = CGPoint(x: screenWidth / 2, y: 100)
-        dart.physicsBody = SKPhysicsBody(rectangleOf: CGSize(width: dart.size.width, height: dart.size.height))
+        dart.position = CGPoint(x: screenWidth / 2, y: 60)
+        dart.physicsBody = SKPhysicsBody(rectangleOf: CGSize(width: 43, height: 56))
         dart.physicsBody?.categoryBitMask = PhysicsCategory.dart
         dart.physicsBody?.contactTestBitMask = PhysicsCategory.dartboard
         dart.physicsBody?.collisionBitMask = PhysicsCategory.dartboard

--- a/Shoong/Shoong/Interaction/Dart/DartView.swift
+++ b/Shoong/Shoong/Interaction/Dart/DartView.swift
@@ -16,7 +16,7 @@ struct DartView: View {
     var body: some View {
         ZStack(alignment: .bottom) {
             SpriteKitContainer(scene: dartScene)
-                .ignoresSafeArea()
+                .edgesIgnoringSafeArea(.all)
             ZStack{
                 HStack(alignment: .bottom) {
                     ThrownCount(count: dartScene.throwingCount)
@@ -27,6 +27,7 @@ struct DartView: View {
                 .padding(.trailing, 16)
                 .padding(.bottom, 24)
             }
+            .offset(y: 30)
             if isMessagePresented {
                 HowToPlay(playImageName: "dartHowToPlay", isMessagePresented: $isMessagePresented)
             }
@@ -39,17 +40,19 @@ struct DartView: View {
                 } label: {
                     HStack(spacing: 4) {
                         Image(systemName: "chevron.backward")
-                            .fontWeight(.semibold)
-                        
+                            .font(.custom("SFPro-Semibold", size: 17))
                         Text("뒤로")
+                            .font(.custom("SFPro-Regular", size: 17))
                     }
                     .foregroundColor(.black)
                 }
             }
-            
             ToolbarItem(placement: .principal) {
-                Text("사직서 날리기")
-                    .bold()
+                Text("다트 던지기")
+                    .font(.custom("SFPro-Semibold", size: 17))
+                    .tracking(-0.4)
+                    .lineSpacing(20)
+                    .foregroundColor(.black)
             }
         }
     }

--- a/Shoong/Shoong/Interaction/Dart/ThrownCount.swift
+++ b/Shoong/Shoong/Interaction/Dart/ThrownCount.swift
@@ -15,7 +15,7 @@ struct ThrownCount: View {
             RoundedRectangle(cornerRadius: 5)
                 .frame(width: 110, height: 60)
                 .foregroundColor(.interactionGray)
-            VStack {
+            VStack(alignment: .leading) {
                 Text("날린 사직서 갯수")
                     .font(.custom("SFPro-Regular", size: 11))
                 Text("\(count)")


### PR DESCRIPTION
## 개요 및 관련 이슈
<!-- PR이 열린 이유와 작업 내용 -->
<!-- - 메인 홈 뷰의 UI를 전체 구현했습니다.(예시) -->

#83 
## 작업 사항
<!-- - 관리자용 대시보드 구현(예시) -->
<!-- - 관리자용 권한 수정 버튼 추가(예시) -->
- 다트 인터랙션 레이아웃 조정했습니다. 
## 주요 로직(Optional)
```diff
- print("변경 전")
+ print("변경 후")
```
