### PR TITLE
[Feat] 볼링, 새총에 게임 방법 메시지 추가

### DIFF
--- a/Shoong/Shoong/Interaction/Bowling/BowlingView.swift
+++ b/Shoong/Shoong/Interaction/Bowling/BowlingView.swift
@@ -10,51 +10,55 @@ import SpriteKit
 
 struct BowlingView: View {
     @Environment(\.dismiss) private var dismiss
-
+    @State private var isMessagePresented = true
+    
     let screenWidth = UIScreen.main.bounds.width
     let screenHeight = UIScreen.main.bounds.height
-
+    
     var myscene: SKScene {
-
+        
         let scene = BowlingGameScene()
-
+        
         scene.size = CGSize(width: screenWidth, height: screenHeight)
         scene.scaleMode = .fill
         scene.backgroundColor = UIColor(.backGroundBeige)
-
-        return scene
-
-    }
-
-    var body: some View {
         
-        SpriteView(scene: myscene)
-            .frame(width: screenWidth, height: screenHeight)
-            .edgesIgnoringSafeArea(.all)
-            .navigationBarBackButtonHidden()
-            .toolbar {
-                ToolbarItem(placement: .navigationBarLeading) {
-                    Button {
-                        dismiss()
-                    } label: {
-                        HStack(spacing: 4) {
-                            Image(systemName: "chevron.backward")
-                                .font(.custom("SFPro-Semibold", size: 17))
-                            Text("뒤로")
-                                .font(.custom("SFPro-Regular", size: 17))
-                        }
-                        .foregroundColor(.black)
-                    }
-                }
-                ToolbarItem(placement: .principal) {
-                    Text("볼링공 던지기")
-                        .font(.custom("SFPro-Semibold", size: 17))
-                        .tracking(-0.4)
-                        .lineSpacing(20)
-                }
-            }
+        return scene
+        
     }
     
+    var body: some View {
+        ZStack {
+            SpriteView(scene: myscene)
+                .frame(width: screenWidth, height: screenHeight)
+                .edgesIgnoringSafeArea(.all)
+            if isMessagePresented {
+                HowToPlay(playImageName: "bowlingHowToPlay", isMessagePresented: $isMessagePresented)
+            }
+        }
+        .navigationBarBackButtonHidden()
+        .toolbar {
+            ToolbarItem(placement: .navigationBarLeading) {
+                Button {
+                    dismiss()
+                } label: {
+                    HStack(spacing: 4) {
+                        Image(systemName: "chevron.backward")
+                            .font(.custom("SFPro-Semibold", size: 17))
+                        Text("뒤로")
+                            .font(.custom("SFPro-Regular", size: 17))
+                    }
+                    .foregroundColor(.black)
+                }
+            }
+            ToolbarItem(placement: .principal) {
+                Text("볼링공 던지기")
+                    .font(.custom("SFPro-Semibold", size: 17))
+                    .tracking(-0.4)
+                    .lineSpacing(20)
+            }
+        }
+    }
 }
 
 struct BowlingView_Previews: PreviewProvider {

--- a/Shoong/Shoong/Interaction/SlingShot/SlingShotGameScene.swift
+++ b/Shoong/Shoong/Interaction/SlingShot/SlingShotGameScene.swift
@@ -11,6 +11,7 @@ import SpriteKit
 
 struct SlingShotGameScene: View {
     @Environment(\.dismiss) private var dismiss
+    @State private var isMessagePresented = true
 
     let screenWidth = UIScreen.main.bounds.width
     let screenHeight = UIScreen.main.bounds.height
@@ -41,6 +42,9 @@ struct SlingShotGameScene: View {
                 .padding(.leading, 19)
                 .padding(.trailing, 16)
                 .padding(.bottom, 24)
+            }
+            if isMessagePresented {
+                HowToPlay(playImageName: "slingshotHowToPlay", isMessagePresented: $isMessagePresented)
             }
         }
         .navigationBarBackButtonHidden()


### PR DESCRIPTION
## 개요 및 관련 이슈
<!-- PR이 열린 이유와 작업 내용 -->
<!-- - 메인 홈 뷰의 UI를 전체 구현했습니다.(예시) -->
#86

## 작업 사항
<!-- - 관리자용 대시보드 구현(예시) -->
<!-- - 관리자용 권한 수정 버튼 추가(예시) -->

- 볼링에 게임 방법 메시지를 수정합니다. 

## 주요 로직(Optional)
```diff
- print("변경 전")
+ print("변경 후")
```
