### PR TITLE
[Fix] 버튼 터치 영역 넓히기

### DIFF
--- a/Shoong/Shoong/Interaction/Dart/HowToPlay.swift
+++ b/Shoong/Shoong/Interaction/Dart/HowToPlay.swift
@@ -21,7 +21,9 @@ struct HowToPlay: View {
                 Button(action: {
                     isMessagePresented = false
                 }, label: {
-                    Image("xmark")})
+                    Image("xmark")
+                        .frame(width: 50, height: 50)
+                })
             }
         }
     }


### PR DESCRIPTION
## 개요 및 관련 이슈
<!-- PR이 열린 이유와 작업 내용 -->
<!-- - 메인 홈 뷰의 UI를 전체 구현했습니다.(예시) -->

#87
## 작업 사항
<!-- - 관리자용 대시보드 구현(예시) -->
<!-- - 관리자용 권한 수정 버튼 추가(예시) -->
- 버튼 터치 영역을 넓혔습니다.

## 주요 로직(Optional)
```diff
- print("변경 전")
+ print("변경 후")
```
