### PR TITLE
96 design 인터랙션 레이아웃 전체 점검 및 수정

### DIFF
--- a/Shoong/Shoong/Assets.xcassets/ColorSet/FontColorSet/interactionWhiteGray.colorset/Contents.json
+++ b/Shoong/Shoong/Assets.xcassets/ColorSet/FontColorSet/interactionWhiteGray.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "156",
+          "green" : "158",
+          "red" : "158"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "156",
+          "green" : "158",
+          "red" : "158"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Shoong/Shoong/Extension+Modifier/Extension+Color.swift
+++ b/Shoong/Shoong/Extension+Modifier/Extension+Color.swift
@@ -36,5 +36,7 @@ extension Color {
     // 인터랙션 내부 컴포넌트 색
     static let interactionGray = Color("interactionGray")
     static let guageOrange = Color("guageOrange")
+    static let interactionWhiteGray = Color("interactionWhiteGray")
+
 
 }

--- a/Shoong/Shoong/Interaction/Dart/HowToPlay.swift
+++ b/Shoong/Shoong/Interaction/Dart/HowToPlay.swift
@@ -15,6 +15,7 @@ struct HowToPlay: View {
         ZStack {
             Rectangle()
                 .ignoresSafeArea()
+                .foregroundColor(.black)
                 .opacity(0.5)
             VStack(spacing: 18) {
                 Image(playImageName)

--- a/Shoong/Shoong/Interaction/Dart/ThrownCount.swift
+++ b/Shoong/Shoong/Interaction/Dart/ThrownCount.swift
@@ -18,8 +18,10 @@ struct ThrownCount: View {
             VStack(alignment: .leading) {
                 Text("날린 사직서 갯수")
                     .font(.custom("SFPro-Regular", size: 11))
+                    .foregroundColor(.black)
                 Text("\(count)")
                     .font(.custom("SFPro-Semibold", size: 15))
+                    .foregroundColor(.black)
             }
         }
     }

--- a/Shoong/Shoong/Interaction/Dart/ThrownCount.swift
+++ b/Shoong/Shoong/Interaction/Dart/ThrownCount.swift
@@ -18,7 +18,7 @@ struct ThrownCount: View {
             VStack(alignment: .leading) {
                 Text("날린 사직서 갯수")
                     .font(.custom("SFPro-Regular", size: 11))
-                    .foregroundColor(.black)
+                    .foregroundColor(.interactionWhiteGray)
                 Text("\(count)")
                     .font(.custom("SFPro-Semibold", size: 15))
                     .foregroundColor(.black)

--- a/Shoong/Shoong/Interaction/SlingShot/SlingShotGameScene.swift
+++ b/Shoong/Shoong/Interaction/SlingShot/SlingShotGameScene.swift
@@ -67,6 +67,7 @@ struct SlingShotGameScene: View {
                     .font(.custom("SFPro-Semibold", size: 17))
                     .tracking(-0.4)
                     .lineSpacing(20)
+                    .foregroundColor(.black)
             }
         }
     }

--- a/Shoong/Shoong/Interaction/SlingShot/SlingShotGameScene.swift
+++ b/Shoong/Shoong/Interaction/SlingShot/SlingShotGameScene.swift
@@ -43,6 +43,7 @@ struct SlingShotGameScene: View {
                 .padding(.trailing, 16)
                 .padding(.bottom, 24)
             }
+            .offset(y: 30)
             if isMessagePresented {
                 HowToPlay(playImageName: "slingshotHowToPlay", isMessagePresented: $isMessagePresented)
             }


### PR DESCRIPTION
## 개요 및 관련 이슈
<!-- PR이 열린 이유와 작업 내용 -->
<!-- - 메인 홈 뷰의 UI를 전체 구현했습니다.(예시) -->
#96 

## 작업 사항
<!-- - 관리자용 대시보드 구현(예시) -->
<!-- - 관리자용 권한 수정 버튼 추가(예시) -->
- 게임 안내 화면 뒤쪽 검정색으로 만들기
- 새총 내비게이션에 글씨 색 수정
- 날린 사직서 갯수 글씨 색 바꾸기
- 컴포넌트 높이 통일시키기

## 주요 로직(Optional)
```diff
- print("변경 전")
+ print("변경 후")
```
